### PR TITLE
Nip13 support for more nostr event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.10.0 - NIP-13 Support
+
+- Edit: `EventPrepare.to_event` method accepts pow difficulty target 
+- Edit: `Client.set_metadata` method accepts pow difficulty target
+- Edit: `Client.publish_text_note` method accepts pow difficulty target
+- Edit: `Client.add_recommended_relay` method accepts pow difficulty target
+- Edit: `EventPrepare::count_leading_zero_bits` method returns u16
+- Edit: `EventPrepare.to_pow_event` method returns Result<(), NIP13Error>
+- Remove: `Client.publish_pow_text_note`
+- Edit: `Client.set_contact_list` method accepts pow difficulty target
+- Edit: `Client.react_to` method accepts pow difficulty target
+- Edit: `Client.like` method accepts pow difficulty target
+- Edit: `Client.dislike` method accepts pow difficulty target
+- Edit: `Client.send_private_message` method accepts pow difficulty target
+- Edit: `Client.delete_event` method accepts pow difficulty target
+- Edit: `Client.delete_event_with_reason` method accepts pow difficulty target  
+
+## 0.9.0 - NIP-11 Support
+
+- Add: `nips::nip11::get_relay_information_document` method
+
 ## 0.8.0 - NIP-13 Support
 
 - Add: `nips::nip13::NIP13Error` enum

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ use std::{
     str::FromStr,
     sync::{Arc, Mutex},
     thread,
-    Message,
 };
 
-use nostr_rust::{nostr_client::Client, req::ReqFilter, Identity};
+use nostr_rust::{nostr_client::Client, req::ReqFilter, Identity, Message};
 
 fn handle_message(relay_url: &String, message: &Message) -> Result<(), String> {
     println!("Received message from {}: {:?}", relay_url, message);
@@ -41,7 +40,7 @@ fn main() {
             .unwrap();
 
     let nostr_client = Arc::new(Mutex::new(
-        Client::new(vec!["wss://relay.nostr.info"]).unwrap(),
+        Client::new(vec!["ws://localhost:7000"]).unwrap(),
     ));
 
     // Run a new thread to handle messages
@@ -64,6 +63,7 @@ fn main() {
             Some("Rust Nostr Client test account"),
             Some("Hello Nostr! #5"),
             None,
+            0,
         )
         .unwrap();
 
@@ -71,20 +71,18 @@ fn main() {
     let subscription_id = nostr_client
         .lock()
         .unwrap()
-        .subscribe(
-            vec![ReqFilter {
-                ids: None,
-                authors: Some(vec![
-                    "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6".to_string(),
-                ]),
-                kinds: None,
-                e: None,
-                p: None,
-                since: None,
-                until: None,
-                limit: Some(1),
-            }],
-        )
+        .subscribe(vec![ReqFilter {
+            ids: None,
+            authors: Some(vec![
+                "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6".to_string(),
+            ]),
+            kinds: None,
+            e: None,
+            p: None,
+            since: None,
+            until: None,
+            limit: Some(1),
+        }])
         .unwrap();
 
     // Unsubscribe
@@ -98,14 +96,23 @@ fn main() {
     nostr_client
         .lock()
         .unwrap()
-        .publish_text_note(&my_identity, "Hello Nostr! :)", &[])
+        .publish_text_note(&my_identity, "Hello Nostr! :)", &[], 0)
+        .unwrap();
+
+    // Publish a proof of work text note with a difficulty target of 15
+    nostr_client
+        .lock()
+        .unwrap()
+        .publish_text_note(&my_identity, "Hello Nostr! :)", &[], 15)
         .unwrap();
 
     // Wait for the thread to finish
     handle_thread.join().unwrap();
 }
-```
 
+
+
+```
 ## NIPs Supported
 
 | NIP                                                            | Supported     | Client Version | Description                                                  |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fn main() {
             .unwrap();
 
     let nostr_client = Arc::new(Mutex::new(
-        Client::new(vec!["ws://localhost:7000"]).unwrap(),
+        Client::new(vec!["wss://relay.nostr.info"]).unwrap(),
     ));
 
     // Run a new thread to handle messages

--- a/src/events.rs
+++ b/src/events.rs
@@ -24,7 +24,7 @@ pub struct EventPrepare {
 }
 
 impl EventPrepare {
-    /// //get_content returns the content of the event to be signed
+    /// get_content returns the content of the event to be signed
     /// # Example
     /// ```rust
     /// use nostr_rust::{events::EventPrepare, utils::get_timestamp};

--- a/src/events.rs
+++ b/src/events.rs
@@ -24,7 +24,7 @@ pub struct EventPrepare {
 }
 
 impl EventPrepare {
-    /// get_content returns the content of the event to be signed
+    /// //get_content returns the content of the event to be signed
     /// # Example
     /// ```rust
     /// use nostr_rust::{events::EventPrepare, utils::get_timestamp};
@@ -78,7 +78,7 @@ impl EventPrepare {
     /// use std::str::FromStr;
     /// use nostr_rust::{events::EventPrepare, Identity};
     ///
-    /// let event = EventPrepare {
+    /// let mut event = EventPrepare {
     ///  pub_key: env!("PUBLIC_KEY").to_string(),
     ///  created_at: 0, // Don't use this in production
     ///  kind: 0,
@@ -87,7 +87,7 @@ impl EventPrepare {
     /// };
     ///
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
-    /// Test to_event without Proof of Work
+    /// // Test to_event without Proof of Work
     /// let nostr_event = event.to_event(&identity, 0);
     /// assert_eq!(nostr_event.id, "4a57aad22fc0fd374e8ceeaaaf8817fa6cb661ca2229c66309d7dba69dfe2359");
     /// assert_eq!(nostr_event.content, "content");
@@ -97,15 +97,15 @@ impl EventPrepare {
     /// assert_eq!(nostr_event.pub_key, env!("PUBLIC_KEY"));
     /// assert_eq!(nostr_event.sig.len(), 128);
     ///
-    /// Test to_event with Proof of Work
+    /// // Test to_event with Proof of Work
     /// let difficulty = 10;
-    /// let nostr_event_pow = event.to_event(&identity, difficulty).unwrap();
+    /// let mut nostr_event_pow = event.to_event(&identity, difficulty);
     /// let event_id = hex::decode(nostr_event_pow.id).unwrap();
     /// let event_difficulty = EventPrepare::count_leading_zero_bits(event_id);
-    /// assert!(event_difficulty >= difficulty);
+    /// assert!(event_difficulty >= difficulty.into());
     /// assert_eq!(nostr_event_pow.content, "content");
     /// assert_eq!(nostr_event_pow.kind, 0);
-    /// assert_eq!(nostr_event.tags_pow.len(), 1);
+    /// assert_eq!(nostr_event_pow.tags.len(), 1);
     /// assert!(nostr_event_pow.created_at > 0);
     /// assert_eq!(nostr_event_pow.pub_key, env!("PUBLIC_KEY"));
     /// assert_eq!(nostr_event_pow.sig.len(), 128);

--- a/src/events.rs
+++ b/src/events.rs
@@ -123,7 +123,7 @@ impl EventPrepare {
 /// Event is the struct used to represent a Nostr event
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Event {
-    /// 32-bytes sha256 of the the serialized event data
+    /// 32-bytes sha256 of the serialized event data
     pub id: String,
     /// 32-bytes hex-encoded public key of the event creator
     #[serde(rename = "pubkey")]

--- a/src/nips/nip1.rs
+++ b/src/nips/nip1.rs
@@ -44,6 +44,7 @@ impl Client {
         name: Option<&str>,
         about: Option<&str>,
         picture: Option<&str>,
+        difficulty_target: u16,
     ) -> Result<Event, NIP1Error> {
         let mut json_body = json!({});
 
@@ -70,7 +71,7 @@ impl Client {
             tags: vec![],
             content: json_body.to_string(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(event)
@@ -91,6 +92,7 @@ impl Client {
         identity: &Identity,
         content: &str,
         tags: &[Vec<String>],
+        difficulty_target: u16,
     ) -> Result<Event, NIP1Error> {
         let event = EventPrepare {
             pub_key: identity.public_key_str.clone(),
@@ -99,7 +101,7 @@ impl Client {
             tags: tags.to_vec(),
             content: content.to_string(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(event)
@@ -120,6 +122,7 @@ impl Client {
         &mut self,
         identity: &Identity,
         relay: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP1Error> {
         let event = EventPrepare {
             pub_key: identity.public_key_str.clone(),
@@ -128,7 +131,7 @@ impl Client {
             tags: vec![],
             content: relay.to_string(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(event)

--- a/src/nips/nip1.rs
+++ b/src/nips/nip1.rs
@@ -36,7 +36,7 @@ impl Client {
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     ///
     /// // Here we set the metadata of the identity but not the profile picture one
-    /// client.set_metadata(&identity, Some("Rust Nostr Client"), Some("Automated account for Rust Nostr Client tests :)"), None).unwrap();
+    /// client.set_metadata(&identity, Some("Rust Nostr Client"), Some("Automated account for Rust Nostr Client tests :)"), None, 0).unwrap();
     /// ```
     pub fn set_metadata(
         &mut self,
@@ -85,7 +85,7 @@ impl Client {
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     /// let message = format!("Hello Nostr! {}", get_timestamp());
-    /// client.publish_text_note(&identity, &message, &vec![]).unwrap();
+    /// client.publish_text_note(&identity, &message, &vec![], 0).unwrap();
     /// ```
     pub fn publish_text_note(
         &mut self,
@@ -115,8 +115,8 @@ impl Client {
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     ///
-    /// // Here we set the recommended relay server to the one hosted by Wellorder
-    /// client.add_recommended_relay(&identity, "wss://relay.damus.io").unwrap();
+    /// // Here we set the recommended relay server to the url set in env
+    /// client.add_recommended_relay(&identity, "wss://relay.damus.io", 0).unwrap();
     /// ```
     pub fn add_recommended_relay(
         &mut self,

--- a/src/nips/nip13.rs
+++ b/src/nips/nip13.rs
@@ -13,9 +13,6 @@ pub enum NIP13Error {
     #[error("Content Id is invalid")]
     InvalidContentId(FromHexError),
 
-    #[error("difficulty is invalid")]
-    InvalidDifficulty(TryFromIntError),
-
     #[error("The client has an error")]
     ClientError(ClientError),
 }
@@ -32,12 +29,6 @@ impl From<FromHexError> for NIP13Error {
     }
 }
 
-impl From<TryFromIntError> for NIP13Error {
-    fn from(err: TryFromIntError) -> Self {
-        Self::InvalidDifficulty(err)
-    }
-}
-
 impl EventPrepare {
     /// Counts leading zero bits to calculate PoW difficulty
     /// # Example
@@ -49,11 +40,11 @@ impl EventPrepare {
     /// let diff = EventPrepare::count_leading_zero_bits(hash);
     /// assert_eq!(diff, 36)
     /// ```
-    pub fn count_leading_zero_bits(content_id: Vec<u8>) -> u32 {
-        let mut total: u32 = 0;
+    pub fn count_leading_zero_bits(content_id: Vec<u8>) -> u16 {
+        let mut total: u16 = 0;
 
         for c in content_id {
-            let bits = c.leading_zeros();
+            let bits = c.leading_zeros() as u16;
             total += bits;
             if bits != 8 {
                 break;
@@ -104,7 +95,7 @@ impl EventPrepare {
             let content_id = self.get_content_id();
             let content_id = hex::decode(content_id)?;
 
-            if Self::count_leading_zero_bits(content_id) >= difficulty.into() {
+            if Self::count_leading_zero_bits(content_id) >= difficulty {
                 break;
             }
 
@@ -113,5 +104,5 @@ impl EventPrepare {
         }
 
         Ok(())
-
-    }}
+    }
+}

--- a/src/nips/nip13.rs
+++ b/src/nips/nip13.rs
@@ -1,5 +1,3 @@
-use std::num::TryFromIntError;
-
 use crate::{events::EventPrepare, nostr_client::ClientError, utils::get_timestamp};
 use hex::FromHexError;
 use rand::Rng;

--- a/src/nips/nip13.rs
+++ b/src/nips/nip13.rs
@@ -78,16 +78,17 @@ impl EventPrepare {
     ///
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     /// let difficulty = 10;
-    /// let nostr_event = event.to_pow_event(&identity, difficulty).unwrap();
-    /// let event_id = hex::decode(nostr_event.id).unwrap();
+    /// event.to_pow_event(difficulty).unwrap();
+    /// let event_id = event.get_content_id();
+    /// let event_id = hex::decode(event_id).unwrap();
     /// let event_difficulty = EventPrepare::count_leading_zero_bits(event_id);
-    /// assert!(event_difficulty >= difficulty);
-    /// assert_eq!(nostr_event.content, "content");
-    /// assert_eq!(nostr_event.kind, 0);
-    /// assert_eq!(nostr_event.tags.len(), 1);
-    /// assert!(nostr_event.created_at > 0);
-    /// assert_eq!(nostr_event.pub_key, env!("PUBLIC_KEY"));
-    /// assert_eq!(nostr_event.sig.len(), 128);
+    /// assert!(event_difficulty >= difficulty.into());
+    /// assert_eq!(event.content, "content");
+    /// assert_eq!(event.kind, 0);
+    /// assert_eq!(event.tags.len(), 1);
+    /// assert!(event.created_at > 0);
+    /// assert_eq!(event.pub_key, env!("PUBLIC_KEY"));
+    ///
     /// ```
     pub fn to_pow_event(&mut self, difficulty: u16) -> Result<(), NIP13Error> {
         let mut rng = rand::thread_rng();

--- a/src/nips/nip2.rs
+++ b/src/nips/nip2.rs
@@ -67,7 +67,8 @@ impl Client {
     ///   key: "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6".to_string(),
     ///   main_relay: Some(env!("RELAY_URL").to_string()),
     ///   surname: Some("Rust Nostr Client".to_string()),
-    /// }]).unwrap();
+    /// }],
+    /// 0).unwrap();
     /// ```
     pub fn set_contact_list(
         &mut self,

--- a/src/nips/nip2.rs
+++ b/src/nips/nip2.rs
@@ -73,6 +73,7 @@ impl Client {
         &mut self,
         identity: &Identity,
         contact_list: Vec<ContactListTag>,
+        difficulty_target: u16,
     ) -> Result<(), NIP2Error> {
         let event = EventPrepare {
             pub_key: identity.public_key_str.clone(),
@@ -84,7 +85,7 @@ impl Client {
                 .collect(),
             content: String::new(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(())

--- a/src/nips/nip25.rs
+++ b/src/nips/nip25.rs
@@ -34,7 +34,7 @@ impl Client {
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     ///
     /// // Here we react to an event
-    /// client.react_to(&identity, "342060554ca30a9792f6e6959675ae734aed02c23e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6", "+").unwrap();
+    /// client.react_to(&identity, "342060554ca30a9792f6e6959675ae734aed02c23e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6", "+", 0).unwrap();
     /// ```
     pub fn react_to(
         &mut self,
@@ -68,7 +68,7 @@ impl Client {
     /// use std::str::FromStr;
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
-    /// client.like(&identity, "342060554ca30a9792f6e6959675ae734aed02c23e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6").unwrap();
+    /// client.like(&identity, "342060554ca30a9792f6e6959675ae734aed0223e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6", 0).unwrap();
     /// ```
     pub fn like(
         &mut self,
@@ -88,7 +88,7 @@ impl Client {
     /// use std::str::FromStr;
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
-    /// client.dislike(&identity, "342060554ca30a9792f6e6959675ae734aed02c23e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6").unwrap();
+    /// client.dislike(&identity, "342060554ca30a9792f6e6959675ae734aed02c23e35037d2a0f72ac6316e83d", "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6", 0).unwrap();
     /// ```
     pub fn dislike(
         &mut self,

--- a/src/nips/nip25.rs
+++ b/src/nips/nip25.rs
@@ -42,6 +42,7 @@ impl Client {
         event_id: &str,
         event_pub_key: &str,
         reaction: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP25Error> {
         let event = EventPrepare {
             pub_key: identity.public_key_str.clone(),
@@ -53,7 +54,7 @@ impl Client {
             ],
             content: reaction.to_string(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(event)
@@ -74,8 +75,9 @@ impl Client {
         identity: &Identity,
         event_id: &str,
         event_pub_key: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP25Error> {
-        self.react_to(identity, event_id, event_pub_key, "+")
+        self.react_to(identity, event_id, event_pub_key, "+", difficulty_target)
     }
 
     /// Add a dislike to an event
@@ -93,7 +95,8 @@ impl Client {
         identity: &Identity,
         event_id: &str,
         event_pub_key: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP25Error> {
-        self.react_to(identity, event_id, event_pub_key, "-")
+        self.react_to(identity, event_id, event_pub_key, "-", difficulty_target)
     }
 }

--- a/src/nips/nip4.rs
+++ b/src/nips/nip4.rs
@@ -118,7 +118,7 @@ impl Client {
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     /// let pubkey = "884704bd421721e292edbff42eb77547fe115c6ff9825b08fc366be4cd69e9f6";
     ///
-    /// client.send_private_message(&identity, pubkey, "Hello from Rust Nostr Client!").unwrap();
+    /// client.send_private_message(&identity, pubkey, "Hello from Rust Nostr Client!", 0).unwrap();
     /// ```
     pub fn send_private_message(
         &mut self,

--- a/src/nips/nip4.rs
+++ b/src/nips/nip4.rs
@@ -125,6 +125,7 @@ impl Client {
         identity: &Identity,
         hex_pubkey: &str,
         message: &str,
+        difficulty_target: u16,
     ) -> Result<Event, Error> {
         let x_pub_key = secp256k1::XOnlyPublicKey::from_str(hex_pubkey)?;
         let encrypted_message = encrypt(&identity.secret_key, &x_pub_key, message)?;
@@ -136,7 +137,7 @@ impl Client {
             tags: vec![vec!["p".to_string(), hex_pubkey.to_string()]],
             content: encrypted_message,
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event).unwrap();
         Ok(event)

--- a/src/nips/nip9.rs
+++ b/src/nips/nip9.rs
@@ -28,11 +28,11 @@ impl Client {
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     /// // Create an event
-    /// let event = client.publish_text_note(&identity, "Hello Nostr! :)", &[])
+    /// let event = client.publish_text_note(&identity, "Hello Nostr! :)", &[], 0)
     ///   .unwrap();
     ///
     /// // Delete the event
-    /// client.delete_event(&identity, &event.id).unwrap();
+    /// client.delete_event(&identity, &event.id, 0).unwrap();
     /// ```
     pub fn delete_event(
         &mut self,
@@ -52,11 +52,11 @@ impl Client {
     /// let mut client = Client::new(vec![env!("RELAY_URL")]).unwrap();
     /// let identity = Identity::from_str(env!("SECRET_KEY")).unwrap();
     /// // Create an event
-    /// let event = client.publish_text_note(&identity, "Hello Nostr! :)", &[])
+    /// let event = client.publish_text_note(&identity, "Hello Nostr! :)", &[], 0)
     ///  .unwrap();
     ///
     /// // Delete the event with a reason
-    /// client.delete_event_with_reason(&identity, &event.id, "This is a reason").unwrap();
+    /// client.delete_event_with_reason(&identity, &event.id, "This is a reason", 0).unwrap();
     /// ```
     pub fn delete_event_with_reason(
         &mut self,

--- a/src/nips/nip9.rs
+++ b/src/nips/nip9.rs
@@ -38,8 +38,9 @@ impl Client {
         &mut self,
         identity: &Identity,
         event_id: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP9Error> {
-        self.delete_event_with_reason(identity, event_id, "")
+        self.delete_event_with_reason(identity, event_id, "", difficulty_target)
     }
 
     /// Delete an event with a reason
@@ -62,6 +63,7 @@ impl Client {
         identity: &Identity,
         event_id: &str,
         reason: &str,
+        difficulty_target: u16,
     ) -> Result<Event, NIP9Error> {
         let event = EventPrepare {
             pub_key: identity.public_key_str.clone(),
@@ -70,7 +72,7 @@ impl Client {
             tags: vec![vec!["e".to_string(), event_id.to_string()]],
             content: reason.to_string(),
         }
-        .to_event(identity);
+        .to_event(identity, difficulty_target);
 
         self.publish_event(&event)?;
         Ok(event)


### PR DESCRIPTION
Changes events and functions that calls it to accept u16 difficulty target argument no add NIP13 support for other types of nostr events. #14 

Includes changing doc test relay from hard coded to env variable. #15 If you prefer the hard coded value let me know I'll change it back :).