### PR TITLE
Event kind field u16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Change: `Event` `kind` field from u8 to u16
+- Change: `EventPrepare` `kind` field from u8 to u16
+
 ## 0.11.0 - Bech32 support
 
 - Add: `bech32::to_bech32` method to convert a `Hex` to a bech32 address

--- a/src/events.rs
+++ b/src/events.rs
@@ -16,7 +16,7 @@ pub struct EventPrepare {
     pub created_at: u64,
     /// integer
     /// 0: NostrEvent
-    pub kind: u8,
+    pub kind: u16,
     /// Tags
     pub tags: Vec<Vec<String>>,
     /// arbitrary string
@@ -150,7 +150,7 @@ pub struct Event {
     pub created_at: u64,
     /// integer
     /// 0: NostrEvent
-    pub kind: u8,
+    pub kind: u16,
     /// Tags
     pub tags: Vec<Vec<String>>,
     /// arbitrary string


### PR DESCRIPTION
The kind field on `Event` and `EventPrepare` are currently u8 but [Ephemeral](https://github.com/nostr-protocol/nips) events can go up to 29999 which will not fit in a u8 so think this should be a u16. 