### PR TITLE
RealayInfoDoc feilds as Option

### DIFF
--- a/src/nips/nip11.rs
+++ b/src/nips/nip11.rs
@@ -6,14 +6,14 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelayInformationDocument {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub pubkey: String,
-    pub contact: String,
-    pub supported_nips: Vec<u16>,
-    pub software: String,
-    pub version: String,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub pubkey: Option<String>,
+    pub contact: Option<String>,
+    pub supported_nips: Option<Vec<u16>>,
+    pub software: Option<String>,
+    pub version: Option<String>,
 }
 
 #[derive(Error, Debug, Eq, PartialEq)]


### PR DESCRIPTION
I think it makes sense to make the `RelayInformationDocument` feilds options as the [NIP11](https://github.com/nostr-protocol/nips/blob/master/11.md) specifics that relays `SHOULD` include the fields not that they `MUST`. And when I tested the current relays only 2 (damus and oxtr) of the 7 actually had all required fields leading the others to throw a `InvalidRelayInformationDocument`. By using options the user of the nostr_rust would still be able to access the fields the relay did return instead of no fields at all and they can handle, what to do with the missing fields. 

relays tested: "wss://relay.damus.io", "wss://nostr-relay.wlvs.space", "wss://relay.nostr.info","wss://nostr-pub.wellorder.net", "wss://nostr.rocks",  "wss://nostr.bitcoiner.social", "wss://nostr.oxtr.dev",

Current:
![Screenshot from 2022-12-03 19-12-05](https://user-images.githubusercontent.com/8606367/205468048-57f9676e-afc5-4386-b638-1932d2abbabe.png)

Using Options:
![Screenshot from 2022-12-03 19-32-06](https://user-images.githubusercontent.com/8606367/205468083-bb15c3e7-06c3-41e1-aafb-25d6067f524c.png)


