### PR TITLE
replace ws with http

### DIFF
--- a/src/nips/nip11.rs
+++ b/src/nips/nip11.rs
@@ -28,6 +28,7 @@ pub enum NIP11Error {
 pub fn get_relay_information_document(
     relay_url: &str,
 ) -> Result<RelayInformationDocument, NIP11Error> {
+    let relay_url = relay_url.replacen("ws", "http", 1);
     let relay_response: RelayInformationDocument = match reqwest::blocking::Client::new()
         .get(relay_url)
         .header("Accept", "application/nostr+json")


### PR DESCRIPTION
The NIP 11 implementation throws a bad schema error because the reqwest expects a http/s url while the nostr client relay urls are wss://. Could do a simple replace on the wss:// to https:// and ws:// to http://, if we assume that the relay uses or doesn't use https based on whether the web socket uses encryption.