### PR TITLE
Remove unwrap() from bech32.rs

### DIFF
--- a/src/bech32.rs
+++ b/src/bech32.rs
@@ -1,3 +1,4 @@
+use hex::FromHexError;
 use bech32::{FromBase32, ToBase32};
 use thiserror::Error;
 
@@ -22,6 +23,13 @@ impl From<bech32::Error> for Bech32Error {
     }
 }
 
+impl From<FromHexError> for Bech32Error {
+    fn from(_err: hex::FromHexError) -> Self {
+        Self::InvalidHex
+    }
+}
+
+
 /// Transform a string (bech32 or hex) into an bech32 string
 ///
 /// # Example
@@ -42,7 +50,7 @@ pub fn to_bech32(kind: ToBech32Kind, key: &str) -> Result<String, Bech32Error> {
             } else {
                 return Ok(bech32::encode(
                     "nsec",
-                    hex::decode(key).unwrap().to_base32(),
+                    hex::decode(key)?.to_base32(),
                     bech32::Variant::Bech32,
                 )?);
             }
@@ -55,7 +63,7 @@ pub fn to_bech32(kind: ToBech32Kind, key: &str) -> Result<String, Bech32Error> {
             } else {
                 return Ok(bech32::encode(
                     "npub",
-                    hex::decode(key).unwrap().to_base32(),
+                    hex::decode(key)?.to_base32(),
                     bech32::Variant::Bech32,
                 )?);
             }
@@ -68,7 +76,7 @@ pub fn to_bech32(kind: ToBech32Kind, key: &str) -> Result<String, Bech32Error> {
             } else {
                 return Ok(bech32::encode(
                     "note",
-                    hex::decode(key).unwrap().to_base32(),
+                    hex::decode(key)?.to_base32(),
                     bech32::Variant::Bech32,
                 )?);
             }


### PR DESCRIPTION
Propagate any hex.decode() errors using the ? operator, instead of causing a panic with unwrap().

Invalid hashes that can be used to test:
* c1110d81778c81c0e84389f3457792ddc2c9f6f0784e8d78c8dbf5986ed418c (odd number)
* c1110d81778c81c0e84389f3457792ddc2c9f6f0784e8d78c8dbf5986ed418cy (invalid hash char)

```rust
use nostr_rust::bech32::{ToBech32Kind, to_bech32};

fn main() {
    let test_event_id = "c1110d81778c81c0e84389f3457792ddc2c9f6f0784e8d78c8dbf5986ed418cb".to_owned();
    let event_bech32 = match to_bech32(ToBech32Kind::Note, &test_event_id) {
        Err(err) => {
            eprintln!("Error: {err:?}");
            return
        },
        Ok(event_bech32) => event_bech32
    };

    println!("{event_bech32}");
}
```