### PR TITLE
Add NIP-03: OpenTimestamps proof in events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 tokio = { version = "1.24", optional = true, features = ["macros"] }
 futures-util = { version = "0.3", optional = true }
 futures = { version = "0.3", optional = true }
+nostr-ots = "0.1.1"


### PR DESCRIPTION
This adds NIP-03 by optionally timestamping `Event` struct.

It's optional because the call to `timestamp_event` requires network calls so I didn't know if this is acceptable for every `Event`.

Moreover, the crate `nostr-ots` which I created yesterday it's not been thoroughly tested yet.